### PR TITLE
Add a function to query SRV records to build rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+          - "3.1"
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/features/functions.feature
+++ b/features/functions.feature
@@ -1,0 +1,21 @@
+Feature: Functions
+  As a systems administrator
+  In order to make the configuration files more manageable
+  I want to be able to use functions to generate the final configuration.
+
+  Scenario: Generate firewall rules using an SRV record
+    A single SRV record can store multiple combinations of host+port for a
+    single service.
+
+    Given a file named "network.puffy" with:
+    """
+    node 'example.com' do
+      pass out proto tcp from any to srv('_x-puppet._tcp.blogreen.org')
+    end
+    """
+    When I successfully run `puffy generate -f Pf network.puffy example.com`
+    Then the stdout should contain:
+    """
+    pass out quick proto tcp to 2a01:4f9:c010:e1dd:: port 8140
+    pass out quick proto tcp to 135.181.146.104 port 8140
+    """

--- a/features/functions.feature
+++ b/features/functions.feature
@@ -10,7 +10,7 @@ Feature: Functions
     Given a file named "network.puffy" with:
     """
     node 'example.com' do
-      pass out proto tcp from any to srv('_x-puppet._tcp.blogreen.org')
+      pass out to srv('_x-puppet._tcp.blogreen.org')
     end
     """
     When I successfully run `puffy generate -f Pf network.puffy example.com`

--- a/lib/core_ext.rb
+++ b/lib/core_ext.rb
@@ -28,19 +28,31 @@ module Expandable
 
   private
 
-  def expand_array(key)
+  def expand_array(key) # rubocop:disable Metrics/MethodLength
     orig = @expand_res
     @expand_res = []
     fetch(key).each do |value|
-      @expand_res += orig.map { |hash| hash.merge(key => value) }
+      if value.respond_to?(:expand)
+        value.expand.each do |v|
+          @expand_res += orig.map { |hash| hash.merge(key => v) }
+        end
+      else
+        @expand_res += orig.map { |hash| hash.merge(key => value) }
+      end
     end
   end
 
-  def expand_hash(key)
+  def expand_hash(key) # rubocop:disable Metrics/MethodLength
     orig = @expand_res
     @expand_res = []
     fetch(key).expand.each do |value|
-      @expand_res += orig.map { |hash| hash.merge(key => value) }
+      if value.respond_to?(:expand)
+        value.expand.each do |v|
+          @expand_res += orig.map { |hash| hash.merge(key => v) }
+        end
+      else
+        @expand_res += orig.map { |hash| hash.merge(key => value) }
+      end
     end
   end
 end

--- a/lib/puffy/parser.y
+++ b/lib/puffy/parser.y
@@ -152,6 +152,7 @@ rule
             | hosts_port                   { result = [{ host: nil, port: val[0] }] }
             | '{' host_list '}' hosts_port { result = [{ host: val[1], port: val[3] }] }
             | VARIABLE hosts_port          { result = [{ host: @variables.fetch(val[0][:value]), port: val[1] }] }
+            | SRV '(' STRING ')'           { result = Resolver.instance.resolv_srv(val[2][:value]) }
             ;
 
   hosts_port: PORT '{' port_list '}' { result = val[2] }
@@ -248,6 +249,8 @@ require 'strscan'
       when s.scan(/,/) then         emit(',', s.matched)
       when s.scan(/{/) then         emit('{', s.matched)
       when s.scan(/}/) then         emit('}', s.matched)
+      when s.scan(/\(/) then        emit('(', s.matched)
+      when s.scan(/\)/) then        emit(')', s.matched)
       when s.scan(/service\b/) then emit(:SERVICE, s.matched)
       when s.scan(/client\b/) then  emit(:CLIENT, s.matched)
       when s.scan(/server\b/) then  emit(:SERVER, s.matched)
@@ -281,6 +284,7 @@ require 'strscan'
       when s.scan(/port\b/) then    emit(:PORT, s.matched)
       when s.scan(/nat-to\b/) then  emit(:NAT_TO, s.matched)
       when s.scan(/rdr-to\b/) then  emit(:RDR_TO, s.matched)
+      when s.scan(/srv\b/) then     emit(:SRV, s.matched)
 
       when s.scan(/\d+\.\d+\.\d+\.\d+(\/\d+)?/) && ip = ipaddress?(s) then           emit(:ADDRESS, ip, s.matched_size)
       when s.scan(/[[:xdigit:]]*:[:[:xdigit:]]+(\/\d+)?/) && ip = ipaddress?(s) then emit(:ADDRESS, ip, s.matched_size)

--- a/lib/puffy/parser.y
+++ b/lib/puffy/parser.y
@@ -137,29 +137,22 @@ rule
   protocol: IDENTIFIER { result = val[0][:value].to_sym }
           ;
 
-  hosts: FROM hosts_from hosts_port TO hosts_to hosts_port { result = { from: { host: val[1], port: val[2] }, to: { host: val[4], port: val[5] } } }
-       | FROM hosts_from hosts_port                        { result = { from: { host: val[1], port: val[2] } } }
-       | TO hosts_from hosts_port                          { result = { to: { host: val[1], port: val[2] } } }
-       | ALL                                               { result = {} }
+  hosts: FROM hosts_host TO hosts_host { result = { from: val[1], to: val[3] } }
+       | FROM hosts_host               { result = { from: val[1] } }
+       | TO hosts_host                 { result = { to: val[1] } }
+       | ALL                           { result = {} }
        ;
 
   optional_hosts: hosts
                 |       { result = {} }
                 ;
 
-  hosts_from: ANY               { result = nil }
-            | '{' host_list '}' { result = val[1] }
-            | host
-            | VARIABLE          { result = @variables.fetch(val[0][:value]) }
-            |
+  hosts_host: ANY hosts_port               { result = [{ host: nil, port: val[1] }] }
+            | host hosts_port              { result = [{ host: val[0], port: val[1] }] }
+            | hosts_port                   { result = [{ host: nil, port: val[0] }] }
+            | '{' host_list '}' hosts_port { result = [{ host: val[1], port: val[3] }] }
+            | VARIABLE hosts_port          { result = [{ host: @variables.fetch(val[0][:value]), port: val[1] }] }
             ;
-
-  hosts_to: ANY               { result = nil }
-          | '{' host_list '}' { result = val[1] }
-          | host
-          | VARIABLE          { result = @variables.fetch(val[0][:value]) }
-          |
-          ;
 
   hosts_port: PORT '{' port_list '}' { result = val[2] }
             | PORT port              { result = val[1] }
@@ -190,9 +183,9 @@ rule
             |                           { result = {} }
             ;
 
-  filteropt: RDR_TO ADDRESS PORT INTEGER { result = { rdr_to: { host: val[1][:value], port: val[3][:value] } } }
-           | RDR_TO ADDRESS { result = { rdr_to: { host: val[1][:value] } } }
-           | NAT_TO ADDRESS { result = { nat_to: val[1][:value] } }
+  filteropt: RDR_TO ADDRESS PORT INTEGER { result = { rdr_to: [{ host: val[1][:value], port: val[3][:value] }] } }
+           | RDR_TO ADDRESS              { result = { rdr_to: [{ host: val[1][:value], port: nil }] } }
+           | NAT_TO ADDRESS              { result = { nat_to: val[1][:value] } }
            ;
 end
 

--- a/lib/puffy/puppet.rb
+++ b/lib/puffy/puppet.rb
@@ -29,9 +29,7 @@ module Puffy
 
         next unless fragment_changed?(fragment_name, fragment_content)
 
-        File.open(fragment_name, 'w') do |f|
-          f.write(fragment_content)
-        end
+        File.write(fragment_name, fragment_content)
       end
     end
 

--- a/lib/puffy/resolver.rb
+++ b/lib/puffy/resolver.rb
@@ -29,6 +29,18 @@ module Puffy
       end
     end
 
+    # Resolve the SRV record for +service+ and return its target and port.
+    #
+    # @example
+    #   Resolver.instance.resolv_srv('_http._tcp.deb.debian.org')
+    #   #=> [{ host: 'debian.map.fastlydns.net.', port: 80 }]
+    #
+    # @param service [String] The service to resolve
+    # @return [Array<Hash>]
+    def resolv_srv(service)
+      @dns.getresources(service, Resolv::DNS::Resource::IN::SRV).collect { |r| { host: r.target.to_s, port: r.port } }.sort
+    end
+
     private
 
     def resolv_ipaddress(address, address_family)

--- a/lib/puffy/resolver.rb
+++ b/lib/puffy/resolver.rb
@@ -38,7 +38,8 @@ module Puffy
     # @param service [String] The service to resolve
     # @return [Array<Hash>]
     def resolv_srv(service)
-      @dns.getresources(service, Resolv::DNS::Resource::IN::SRV).collect { |r| { host: r.target.to_s, port: r.port } }.sort
+      proto = service.split('.')[1][1..-1].to_sym
+      @dns.getresources(service, Resolv::DNS::Resource::IN::SRV).collect { |r| { host: r.target.to_s, port: r.port, proto_hint: proto } }.sort
     end
 
     private

--- a/lib/puffy/rule.rb
+++ b/lib/puffy/rule.rb
@@ -66,6 +66,8 @@ module Puffy
 
       @af = detect_af unless af
 
+      self.proto ||= from_proto_hint || to_proto_hint
+
       raise "unsupported action `#{options[:action]}'" unless valid_action?
       raise 'if from_port or to_port is specified, the protocol must also be given' if port_without_protocol?
     end
@@ -138,16 +140,22 @@ module Puffy
     #   Returns the source host of the Puffy::Rule.
     # @!method from_port
     #   Returns the source port of the Puffy::Rule.
+    # @!method from_proto_hint
+    #   Returns the proto hint of the Puffy::Rule.
     # @!method to_host
     #   Returns the destination host of the Puffy::Rule.
     # @!method to_port
     #   Returns the destination port of the Puffy::Rule.
+    # @!method to_proto_hint
+    #   Returns the proto hint of the Puffy::Rule.
     # @!method rdr_to_host
     #   Returns the redirect destination host of the Puffy::Rule.
     # @!method rdr_to_port
     #   Returns the redirect destination port of the Puffy::Rule.
+    # @!method rdr_to_proto_hint
+    #   Returns the proto hint of the Puffy::Rule (does not make sense).
     %i[from to rdr_to].each do |destination|
-      %i[host port].each do |param|
+      %i[host port proto_hint].each do |param|
         define_method("#{destination}_#{param}") do
           res = public_send(destination)
           res && res[param]

--- a/lib/puffy/rule_factory.rb
+++ b/lib/puffy/rule_factory.rb
@@ -34,7 +34,7 @@ module Puffy
     def build(options = {})
       return [] if options == {}
 
-      options = { action: nil, return: false, dir: nil, af: nil, proto: nil, on: nil, from: { host: nil, port: nil }, to: { host: nil, port: nil }, nat_to: nil, rdr_to: { host: nil, port: nil } }.merge(options)
+      options = { action: nil, return: false, dir: nil, af: nil, proto: nil, on: nil, from: [{ host: nil, port: nil }], to: [{ host: nil, port: nil }], nat_to: nil, rdr_to: [{ host: nil, port: nil }] }.merge(options)
 
       options = resolv_hostnames_and_ports(options)
       instanciate_rules(options)
@@ -44,8 +44,10 @@ module Puffy
 
     def resolv_hostnames_and_ports(options)
       %i[from to rdr_to].each do |endpoint|
-        options[endpoint][:host] = host_lookup(options[endpoint][:host])
-        options[endpoint][:port] = port_lookup(options[endpoint][:port])
+        options[endpoint].map do |ep|
+          ep[:host] = host_lookup(ep[:host])
+          ep[:port] = port_lookup(ep[:port])
+        end
       end
       options[:nat_to] = host_lookup(options[:nat_to])
       options

--- a/puffy.gemspec
+++ b/puffy.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage
   spec.metadata['changelog_uri'] = spec.homepage
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/spec/core_ext_spec.rb
+++ b/spec/core_ext_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'core_ext'
+
+RSpec.describe Hash do
+  describe '#expand' do
+    describe 'No expansion' do
+      subject { { a: :b }.expand }
+      it { is_expected.to eq([{ a: :b }]) }
+    end
+
+    describe 'Single expansion' do
+      subject { { a: %i[b c] }.expand }
+      it do
+        is_expected.to eq([
+                            { a: :b },
+                            { a: :c },
+                          ])
+      end
+    end
+
+    describe 'Multiple expansions' do
+      subject { { a: %i[b c], d: %i[e f] }.expand }
+      it do
+        is_expected.to eq([
+                            { a: :b, d: :e },
+                            { a: :c, d: :e },
+                            { a: :b, d: :f },
+                            { a: :c, d: :f },
+                          ])
+      end
+    end
+
+    describe 'Nested Array expansions' do
+      subject { { a: [{ b: { c: %i[d e] } }] }.expand }
+      it do
+        is_expected.to eq([
+                            { a: { b: { c: :d } } },
+                            { a: { b: { c: :e } } },
+                          ])
+      end
+    end
+
+    describe 'Nested Hash expansions' do
+      subject { { a: [{ b: [{ c: :d }, { e: :f }] }] }.expand }
+      it do
+        is_expected.to eq([
+                            { a: { b: { c: :d } } },
+                            { a: { b: { e: :f } } },
+                          ])
+      end
+    end
+  end
+end

--- a/spec/puffy/rule_factory_spec.rb
+++ b/spec/puffy/rule_factory_spec.rb
@@ -26,12 +26,12 @@ module Puffy
     end
 
     it 'passes addresses and networks' do
-      result = subject.build(to: { host: IPAddr.new('192.0.2.1') })
+      result = subject.build(to: [{ host: IPAddr.new('192.0.2.1') }])
 
       expect(result.count).to eq(1)
       expect(result[0].to[:host]).to eq(IPAddr.new('192.0.2.1'))
 
-      result = subject.build(to: { host: IPAddr.new('192.0.2.0/24') })
+      result = subject.build(to: [{ host: IPAddr.new('192.0.2.0/24') }])
 
       expect(result.count).to eq(1)
       expect(result[0].to[:host]).to eq(IPAddr.new('192.0.2.0/24'))
@@ -41,7 +41,7 @@ module Puffy
       expect(Rule).to receive(:new).twice.and_call_original
       expect(Puffy::Resolver.instance).to receive(:resolv).with('example.com').and_return([IPAddr.new('2001:DB8::1'), IPAddr.new('192.0.2.1')])
 
-      result = subject.build(to: { host: 'example.com' })
+      result = subject.build(to: [{ host: 'example.com' }])
 
       expect(result.count).to eq(2)
       expect(result[0].to[:host]).to eq(IPAddr.new('2001:DB8::1'))
@@ -51,7 +51,7 @@ module Puffy
     it 'accepts service names' do
       expect(Rule).to receive(:new).twice.and_call_original
 
-      result = subject.build(proto: :tcp, to: { port: %w[http https] })
+      result = subject.build(proto: :tcp, to: [{ port: %w[http https] }])
 
       expect(result.count).to eq(2)
       expect(result[0].proto).to eq(:tcp)
@@ -59,13 +59,13 @@ module Puffy
       expect(result[1].proto).to eq(:tcp)
       expect(result[1].to[:port]).to eq(443)
 
-      expect { subject.build(to: { port: 'invalid' }) }.to raise_error('unknown service "invalid"')
+      expect { subject.build(to: [{ port: 'invalid' }]) }.to raise_error('unknown service "invalid"')
     end
 
     it 'accepts service alt-names' do
       expect(Rule).to receive(:new).exactly(3).times.and_call_original
 
-      result = subject.build(proto: :tcp, to: { port: %w[auth tap ident] })
+      result = subject.build(proto: :tcp, to: [{ port: %w[auth tap ident] }])
 
       expect(result.count).to eq(3)
       expect(result[0].proto).to eq(:tcp)
@@ -82,7 +82,7 @@ module Puffy
 
       expect(Rule).to receive(:new).exactly(4).times.and_call_original
 
-      result = subject.build(from: { host: 'example.net' }, to: { host: 'example.com' })
+      result = subject.build(from: [{ host: 'example.net' }], to: [{ host: 'example.com' }])
 
       expect(result.count).to eq(2)
       expect(result[0].from[:host]).to eq(IPAddr.new('2001:DB8::FFFF:FFFF:FFFF'))
@@ -103,13 +103,13 @@ module Puffy
       result = []
 
       subject.ipv4 do
-        result = subject.build(to: { host: 'example.com' })
+        result = subject.build(to: [{ host: 'example.com' }])
       end
       expect(result.count).to eq(1)
       expect(result[0].to[:host]).to eq(IPAddr.new('93.184.216.34'))
 
       subject.ipv6 do
-        result = subject.build(to: { host: 'example.com' })
+        result = subject.build(to: [{ host: 'example.com' }])
       end
       expect(result.count).to eq(1)
       expect(result[0].to[:host]).to eq(IPAddr.new('2606:2800:220:1:248:1893:25c8:1946'))


### PR DESCRIPTION
Add a srv() function that queries the DNS for SRV records and return
endpoints usable in from / to host rules.

This makes it easier to maintain ruleset with dynamic resources by
postponing the resolution of these SRV records the same way name
resolution only happen when gererating the final final firewall rules.