### PR TITLE
Fix node list support

### DIFF
--- a/lib/puffy/parser.y
+++ b/lib/puffy/parser.y
@@ -21,7 +21,7 @@ rule
   service_name: IDENTIFIER { result = val[0][:value] }
               | STRING     { result = val[0][:value] }
 
-  node: NODE '{' node_name_list '}' block_with_policy { @nodes[val[2]] = val[4]; @saved_policies[val[2]] = @policy }
+  node: NODE '{' node_name_list '}' block_with_policy { val[2].each { |name| @nodes[name] = val[4]; @saved_policies[name] = @policy } }
       | NODE node_name block_with_policy              { @nodes[val[1]] = val[2]; @saved_policies[val[1]] = @policy }
 
   node_name_list: node_name_list ',' node_name { result = val[0] + [val[2]] }


### PR DESCRIPTION
When using a list of node names to generate a bunch of rules (`node {'node1', 'node2'} { pass in all }`), we fail to iterate on the list names to assign rules to each node.  Then, when we create the actual configuration, we cannot access the rules and an exception is raised:

```
Traceback (most recent call last):
	13: from /home/romain/.vendor/ruby/2.7.0/bin/puffy:23:in `<main>'
	12: from /home/romain/.vendor/ruby/2.7.0/bin/puffy:23:in `load'
	11: from /home/romain/.vendor/ruby/2.7.0/gems/puffy-0.1.0/bin/puffy:10:in `<top (required)>'
	10: from /home/romain/.vendor/ruby/2.7.0/gems/puffy-0.1.0/lib/puffy/cli.rb:129:in `execute'
	 9: from /home/romain/.vendor/ruby/2.7.0/gems/cri-2.15.11/lib/cri/command.rb:316:in `run'
	 8: from /home/romain/.vendor/ruby/2.7.0/gems/cri-2.15.11/lib/cri/command.rb:316:in `run'
	 7: from /home/romain/.vendor/ruby/2.7.0/gems/cri-2.15.11/lib/cri/command.rb:298:in `run'
	 6: from /home/romain/.vendor/ruby/2.7.0/gems/cri-2.15.11/lib/cri/command.rb:362:in `run_this'
	 5: from /home/romain/.vendor/ruby/2.7.0/gems/puffy-0.1.0/lib/puffy/cli.rb:111:in `block (2 levels) in initialize'
	 4: from /home/romain/.vendor/ruby/2.7.0/gems/puffy-0.1.0/lib/puffy/puppet.rb:27:in `save'
	 3: from /home/romain/.vendor/ruby/2.7.0/gems/puffy-0.1.0/lib/puffy/puppet.rb:56:in `each_fragment'
	 2: from /home/romain/.vendor/ruby/2.7.0/gems/puffy-0.1.0/lib/puffy/puppet.rb:56:in `each'
	 1: from /home/romain/.vendor/ruby/2.7.0/gems/puffy-0.1.0/lib/puffy/puppet.rb:57:in `block in each_fragment'
parser.y:364:in `ruleset_for': undefined method `map' for nil:NilClass (NoMethodError)
```

Iterate through the list to add all rules and fix the issue.