### PR TITLE
Add missing require

### DIFF
--- a/lib/puffy/parser.y
+++ b/lib/puffy/parser.y
@@ -158,6 +158,7 @@ end
 ---- header
 
 require 'deep_merge'
+require 'ipaddr'
 require 'strscan'
 
 ---- inner


### PR DESCRIPTION
Depending on the way we use puffy, we might encounter an exception about
unknown class IPAddr.
