### PR TITLE
Fix parsing IPv6 addresses starting with `:`

### DIFF
--- a/lib/puffy/parser.y
+++ b/lib/puffy/parser.y
@@ -210,13 +210,6 @@ require 'strscan'
           end
           n += 1
         end
-      when s.scan(/=/) then         emit('=', s.matched)
-      when s.scan(/:/) then         emit(':', s.matched)
-      when s.scan(/,/) then         emit(',', s.matched)
-      when s.scan(/{/) then         emit('{', s.matched)
-      when s.scan(/}/) then         emit('}', s.matched)
-      when s.scan(/\(/) then        emit('(', s.matched)
-      when s.scan(/\)/) then        emit(')', s.matched)
       when s.scan(/service\b/) then emit(:SERVICE, s.matched)
       when s.scan(/client\b/) then  emit(:CLIENT, s.matched)
       when s.scan(/server\b/) then  emit(:SERVER, s.matched)
@@ -258,6 +251,14 @@ require 'strscan'
 
       when s.scan(/\d+/) then      emit(:INTEGER, s.matched.to_i, s.matched_size)
       when s.scan(/\w[\w-]+/) then emit(:IDENTIFIER, s.matched)
+
+      when s.scan(/=/) then         emit('=', s.matched)
+      when s.scan(/:/) then         emit(':', s.matched)
+      when s.scan(/,/) then         emit(',', s.matched)
+      when s.scan(/{/) then         emit('{', s.matched)
+      when s.scan(/}/) then         emit('}', s.matched)
+      when s.scan(/\(/) then        emit('(', s.matched)
+      when s.scan(/\)/) then        emit(')', s.matched)
       else
         raise SyntaxError.new('Syntax error', { filename: @filename, lineno: @lineno, position: @position, line: @line })
       end

--- a/spec/puffy/parser_spec.rb
+++ b/spec/puffy/parser_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'puffy'
+
+RSpec.describe Puffy::Parser do
+  let(:config) do
+    <<~CONFIG
+      localhost = {127.0.0.1 ::1}
+    CONFIG
+  end
+
+  it 'parses successfuly' do
+    expect { subject.parse(config) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Due to pattern ordering, we match `:` as a column before matching an IPv6 address starting with `:`.