### PR TITLE
Fix iptables rules without direction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -7,6 +7,7 @@ Feature: Generate firewall rules
     Given a file named "network.puffy" with:
     """
     node 'example.com' do
+      pass proto tcp from any to port ssh
       pass in proto tcp from any to port {http https}
     end
     """
@@ -15,6 +16,7 @@ Feature: Generate firewall rules
     When I successfully run `puffy generate -f Pf network.puffy example.com`
     Then the stdout should contain:
     """
+    pass quick proto tcp to any port 22
     pass in quick proto tcp to any port 80
     pass in quick proto tcp to any port 443
     """
@@ -23,14 +25,24 @@ Feature: Generate firewall rules
     When I successfully run `puffy generate -f Iptables4 network.puffy example.com`
     Then the stdout should contain:
     """
+    -A INPUT -m conntrack --ctstate NEW -p tcp --dport 22 -j ACCEPT
     -A INPUT -m conntrack --ctstate NEW -p tcp --dport 80 -j ACCEPT
     -A INPUT -m conntrack --ctstate NEW -p tcp --dport 443 -j ACCEPT
+    """
+    And the stdout should contain:
+    """
+    -A OUTPUT -m conntrack --ctstate NEW -p tcp --dport 22 -j ACCEPT
     """
 
   Scenario: Generate IPv6 firewall rules for a Linux node
     When I successfully run `puffy generate -f Iptables6 network.puffy example.com`
     Then the stdout should contain:
     """
+    -A INPUT -m conntrack --ctstate NEW -p tcp --dport 22 -j ACCEPT
     -A INPUT -m conntrack --ctstate NEW -p tcp --dport 80 -j ACCEPT
     -A INPUT -m conntrack --ctstate NEW -p tcp --dport 443 -j ACCEPT
+    """
+    And the stdout should contain:
+    """
+    -A OUTPUT -m conntrack --ctstate NEW -p tcp --dport 22 -j ACCEPT
     """

--- a/lib/puffy/formatters/iptables.rb
+++ b/lib/puffy/formatters/iptables.rb
@@ -106,11 +106,19 @@ module Puffy
         end
 
         def input_filter_rules(rules)
-          rules.select { |r| r.filter? && r.in? }
+          rules.select { |r| r.filter? && r.in? }.map do |rule|
+            dup = rule.dup
+            dup.dir = :in
+            dup
+          end
         end
 
         def output_filter_rules(rules)
-          rules.select { |r| r.filter? && r.out? }
+          rules.select { |r| r.filter? && r.out? }.map do |rule|
+            dup = rule.dup
+            dup.dir = :out
+            dup
+          end
         end
       end
 


### PR DESCRIPTION
A rule without direction should generate 2 iptables rules, one for the
INPUT chain, and the other for the OUTPUT chain.
