### PR TITLE
Ensure parser is up-to-date before build

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ AllCops:
   AllowSymlinksInCacheRootDirectory: true
   NewCops: enable
   Exclude:
-    - lib/melt/*.tab.rb
+    - lib/puffy/*.tab.rb
     - tmp/**/*.rb
     - vendor/bundle/**/*
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,16 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in puffy.gemspec
 gemspec
+
+gem 'aruba'
+gem 'bundler'
+gem 'cucumber'
+gem 'github_changelog_generator'
+gem 'racc'
+gem 'rake'
+gem 'rspec'
+gem 'rubocop'
+gem 'rubocop-rake'
+gem 'rubocop-rspec'
+gem 'simplecov'
+gem 'timecop'

--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,8 @@ task test: %i[spec features]
 
 task default: :test
 
+task build: :gen_parser
+
 desc 'Generate the puffy language parser'
 task gen_parser: 'lib/puffy/parser.tab.rb'
 

--- a/puffy.gemspec
+++ b/puffy.gemspec
@@ -33,17 +33,4 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'cri'
   spec.add_runtime_dependency 'deep_merge'
-
-  spec.add_development_dependency 'aruba'
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'cucumber'
-  spec.add_development_dependency 'github_changelog_generator'
-  spec.add_development_dependency 'racc'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'rubocop-rake'
-  spec.add_development_dependency 'rubocop-rspec'
-  spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'timecop'
 end


### PR DESCRIPTION
When building a gem for a release, we want to make sure that we ship an
up-to-date version of the parser.
