### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v1.0.0](https://github.com/opus-codium/puffy/tree/v1.0.0) (2024-04-09)
+
+[Full Changelog](https://github.com/opus-codium/puffy/compare/v0.3.1...v1.0.0)
+
+**Implemented enhancements:**
+
+- Setup dependabot [\#36](https://github.com/opus-codium/puffy/pull/36) ([smortex](https://github.com/smortex))
+- Add support for Ruby 3.3 [\#33](https://github.com/opus-codium/puffy/pull/33) ([smortex](https://github.com/smortex))
+
 ## [v0.3.1](https://github.com/opus-codium/puffy/tree/v0.3.1) (2023-11-22)
 
 [Full Changelog](https://github.com/opus-codium/puffy/compare/v0.3.0...v0.3.1)

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ Cucumber::Rake::Task.new(:features)
 GitHubChangelogGenerator::RakeTask.new :changelog do |config|
   config.user = 'opus-codium'
   config.project = 'puffy'
-  config.exclude_labels = ['skip-changelog']
+  config.exclude_labels = %w[dependencies skip-changelog]
   config.future_release = "v#{Puffy::VERSION}"
 end
 

--- a/lib/puffy/version.rb
+++ b/lib/puffy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Puffy # :nodoc:
-  VERSION = '0.3.1'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
We have been using this in production for years, releasing a 1.0.0 will allow our semantic versionning to make more sense.
