### PR TITLE
Add support for variables in host/port lists

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,9 @@ task test: %i[spec features]
 
 task default: :test
 
+task feature: :gen_parser
 task build: :gen_parser
+task spec: :gen_parser
 
 desc 'Generate the puffy language parser'
 task gen_parser: 'lib/puffy/parser.tab.rb'

--- a/lib/puffy/parser.y
+++ b/lib/puffy/parser.y
@@ -16,6 +16,7 @@ rule
   variable_value: ADDRESS  { result = val[0][:value] }
                 | STRING   { result = val[0][:value] }
                 | VARIABLE { result = @variables.fetch(val[0][:value]) }
+                | port     { result = val[0] }
 
   service: SERVICE service_name block { @services[val[1]] = val[2] }
 
@@ -132,9 +133,12 @@ rule
             | PORT port              { result = val[1] }
             |
 
-  port_list: port_list ',' port { result = val[0] + [val[2]] }
-           | port_list port     { result = val[0] + [val[1]] }
-           | port               { result = [val[0]] }
+  port_list: port_list ',' port_list_item { result = val[0] + val[2] }
+           | port_list port_list_item     { result = val[0] + val[1] }
+           | port_list_item               { result = val[0] }
+
+  port_list_item: port     { result = [val[0]] }
+                | VARIABLE { result = @variables.fetch(val[0][:value]) }
 
   port: INTEGER             { result = val[0][:value] }
       | IDENTIFIER          { result = val[0][:value] }
@@ -143,9 +147,12 @@ rule
   host: ADDRESS { result = val[0][:value] }
       | STRING  { result = val[0][:value] }
 
-  host_list: host_list ',' host { result = val[0] + [val[2]] }
-           | host_list host     { result = val[0] + [val[1]] }
-           | host               { result = [val[0]] }
+  host_list: host_list ',' host_list_item { result = val[0] + val[2] }
+           | host_list host_list_item     { result = val[0] + val[1] }
+           | host_list_item               { result = val[0] }
+
+  host_list_item: host     { result = [val[0]] }
+                | VARIABLE { result = @variables.fetch(val[0][:value]) }
 
   filteropts: filteropts ',' filteropt  { result = val[0].merge(val[2]) }
             | filteropts filteropt      { result = val[0].merge(val[1]) }

--- a/spec/puffy/rule_spec.rb
+++ b/spec/puffy/rule_spec.rb
@@ -12,16 +12,16 @@ module Puffy
     it 'detects IPv4 rules' do
       expect(Rule.new.ipv4?).to be_truthy
       expect(Rule.new(action: :block, dir: :out, proto: :tcp, to: { port: 80 }).ipv4?).to be_truthy
-      expect(Rule.new(action: :block, dir: :out, proto: :tcp, to: { host: IPAddr.new('192.0.2.1'), port: 80 }).ipv4?).to be_truthy
-      expect(Rule.new(action: :block, dir: :out, proto: :tcp, to: { host: IPAddr.new('2001:DB8::1'), port: 80 }).ipv4?).to be_falsy
+      expect(Rule.new(action: :block, dir: :out, proto: :tcp, to: { host: IPAddr.new('203.0.113.42'), port: 80 }).ipv4?).to be_truthy
+      expect(Rule.new(action: :block, dir: :out, proto: :tcp, to: { host: IPAddr.new('2001:db8:fa4e:adde::42'), port: 80 }).ipv4?).to be_falsy
       expect(Rule.new(action: :pass, dir: :fwd, in: 'eth0', out: 'eth1').ipv4?).to be_truthy
     end
 
     it 'detects IPv6 rules' do
       expect(Rule.new.ipv6?).to be_truthy
       expect(Rule.new(action: :block, dir: :out, proto: :tcp, to: { port: 80 }).ipv6?).to be_truthy
-      expect(Rule.new(action: :block, dir: :out, proto: :tcp, to: { host: IPAddr.new('192.0.2.1'), port: 80 }).ipv6?).to be_falsy
-      expect(Rule.new(action: :block, dir: :out, proto: :tcp, to: { host: IPAddr.new('2001:DB8::1'), port: 80 }).ipv6?).to be_truthy
+      expect(Rule.new(action: :block, dir: :out, proto: :tcp, to: { host: IPAddr.new('203.0.113.42'), port: 80 }).ipv6?).to be_falsy
+      expect(Rule.new(action: :block, dir: :out, proto: :tcp, to: { host: IPAddr.new('2001:db8:fa4e:adde::42'), port: 80 }).ipv6?).to be_truthy
       expect(Rule.new(action: :pass, dir: :fwd, in: 'eth0', out: 'eth1').ipv6?).to be_truthy
     end
 
@@ -45,7 +45,7 @@ module Puffy
       expect(Rule.new.rdr?).to be_falsy
       expect(Rule.new(action: :pass, dir: :in, proto: :tcp, to: { port: 80 }).rdr?).to be_falsy
       expect(Rule.new(action: :pass, dir: :out, on: 'eth0', nat_to: IPAddr.new('198.51.100.72')).rdr?).to be_falsy
-      expect(Rule.new(action: :pass, dir: :in, on: 'eth0', rdr_to: { host: IPAddr.new('192.0.2.1') }).rdr?).to be_truthy
+      expect(Rule.new(action: :pass, dir: :in, on: 'eth0', rdr_to: { host: IPAddr.new('203.0.113.42') }).rdr?).to be_truthy
       expect(Rule.new(action: :pass, dir: :fwd, in: 'eth0', out: 'eth1').rdr?).to be_falsy
     end
 
@@ -53,7 +53,7 @@ module Puffy
       expect(Rule.new.nat?).to be_falsy
       expect(Rule.new(action: :pass, dir: :out, proto: :tcp, to: { port: 80 }).nat?).to be_falsy
       expect(Rule.new(action: :pass, dir: :out, on: 'eth0', nat_to: IPAddr.new('198.51.100.72')).nat?).to be_truthy
-      expect(Rule.new(action: :pass, dir: :in, on: 'eth0', rdr_to: { host: IPAddr.new('192.0.2.1') }).nat?).to be_falsy
+      expect(Rule.new(action: :pass, dir: :in, on: 'eth0', rdr_to: { host: IPAddr.new('203.0.113.42') }).nat?).to be_falsy
       expect(Rule.new(action: :pass, dir: :fwd, in: 'eth0', out: 'eth1').nat?).to be_falsy
     end
 
@@ -61,7 +61,7 @@ module Puffy
       expect(Rule.new.fwd?).to be_falsy
       expect(Rule.new(action: :pass, dir: :out, proto: :tcp, to: { port: 80 }).fwd?).to be_falsy
       expect(Rule.new(action: :pass, dir: :out, on: 'eth0', nat_to: IPAddr.new('198.51.100.72')).fwd?).to be_falsy
-      expect(Rule.new(action: :pass, dir: :in, on: 'eth0', rdr_to: { host: IPAddr.new('192.0.2.1') }).fwd?).to be_falsy
+      expect(Rule.new(action: :pass, dir: :in, on: 'eth0', rdr_to: { host: IPAddr.new('203.0.113.42') }).fwd?).to be_falsy
       expect(Rule.new(action: :pass, dir: :fwd, in: 'eth0', out: 'eth1').fwd?).to be_truthy
     end
 


### PR DESCRIPTION
Allow to pass variables as items of host lists and port lists.

This allows constructs like this:

```
clients = { 192.168.0.10 192.168.0.20 }
ports   = { 123 5432 }

node 'test' {
  pass in proto tcp from any to { $clients 10.0.0.10 } port { $ports 3000 }
}
```
